### PR TITLE
added new copy of dockerfile for terra-tools docker image for automation usage

### DIFF
--- a/terra-tools/2024-08-27/Dockerfile
+++ b/terra-tools/2024-08-27/Dockerfile
@@ -1,0 +1,90 @@
+# Dockerfile modified from here: https://github.com/broadinstitute/terra-tools/blob/master/Dockerfile
+# updated 2023-06-21 to bring more tool up to date
+# updated 2023-08-08 to include modified tsv_to_newline_json.py script that handles 'None' values for integers & floats
+# updated 2023-08-22 to update to theiagen/utilities v0.3
+# updated 2023-08-28 to update file permissions (make scripts executable)
+# updated again to bring in recent script changes 
+# v4 - updated to bring in more script changes
+
+FROM google/cloud-sdk:443.0.0-slim
+
+# for easy upgrade later
+#ARG THEIAGEN_UTILITIES_VER="0.3"
+
+# using git commit hash instead of version for pulling Theiagen/Utilies code
+ENV THEIAGEN_UTILITIES_COMMIT="5a96775"
+
+# Tell gcloud to save state in /.config so it's easy to override as a mounted volume.
+ENV HOME=/
+
+# install stuff via apt; cleanup apt garbage
+RUN apt-get update && apt-get install -y --no-install-recommends \
+ ca-certificates \
+ wget \
+ python3 \
+ python3-pip \
+ python3-setuptools \
+ jq \
+ wkhtmltopdf \
+ gawk \
+ git \
+ csvkit && \
+ apt-get autoclean && rm -rf /var/lib/apt/lists/*
+
+# # grab theiagen/utilities code
+# # copy over scripts into /scripts within the container filesystem
+# RUN wget https://github.com/theiagen/utilities/archive/refs/tags/v${THEIAGEN_UTILITIES_VER}.tar.gz && \
+#  tar -xzf v${THEIAGEN_UTILITIES_VER}.tar.gz && \
+#  rm -v v${THEIAGEN_UTILITIES_VER}.tar.gz && \
+#  mkdir /scripts && \
+#  cp -v utilities-${THEIAGEN_UTILITIES_VER}/scripts/* /scripts
+
+# grab theiagen/utilities code
+# copy over scripts into /scripts within the container filesystem
+RUN git clone https://github.com/theiagen/utilities && \
+ mv -v /utilities/ /utilities-0.2/ && \
+ cd utilities-0.2/ && \
+ git checkout ${THEIAGEN_UTILITIES_COMMIT} && \
+ mkdir /scripts && \
+ cp -v scripts/* /scripts
+
+# clone broad/terra-tools repo
+# copying scripts dir to `/scripts` for consistency
+# make all scripts within /scripts exectuable to all users
+RUN git clone https://github.com/broadinstitute/terra-tools.git && \
+ cp -vr /terra-tools/scripts/* /scripts && \
+ chmod +x /scripts/*
+
+# original requirements.txt from broadinstitute/terra-tools repo:
+# firecloud==0.16.26
+# google-auth-httplib2==0.0.3
+# gcs-oauth2-boto-plugin==2.5
+# google-api-python-client==1.8.0
+# google-cloud-storage==1.38.0
+# google-cloud-bigquery==2.7.0
+# pandas==1.3.0
+# tqdm==4.35.0
+
+# we are installing updated versions of each of the following via pip3/pypi:
+RUN pip3 install firecloud \
+google-auth-httplib2 \
+gcs-oauth2-boto-plugin \
+google-api-python-client \
+google-cloud-storage \
+google-cloud-bigquery \
+pandas \
+scipy \
+numpy \
+pdfkit \
+pretty_html_table \
+tqdm \
+pyfaidx
+
+# final working directory is /data
+WORKDIR /data
+
+# put broadinstitute/terra-tools scripts onto the PATH
+ENV PATH=${PATH}:/scripts
+
+# check that we have stuff installed
+RUN gawk --help && jq --help && gsutil help && pip3 list

--- a/terra-tools/README.md
+++ b/terra-tools/README.md
@@ -12,6 +12,7 @@ This docker image contains the following tools:
 - pdfkit
 - pretty-html-table
 - scipy
+- csvkit (specifically for this command: `csvcut`)
 
 ## Docker image tags
 
@@ -19,7 +20,18 @@ Our organization isn't the best. We started off using the version of Theiagen/Ut
 
 BUT since dates are more informative to us we are going to stick with using dates. So the date signifies when the docker image was edited, rebuilt, and pushed to the Theiagen Google artifact registry.
 
-```bash
-# example
+## Changelog
 
+`2024-08-27`: added `csvkit` to dockerfile & docker image to allow use of the CLI tool `csvcut`.
+
+## Build & Deploy
+
+Run these commands to build the docker image locally and push it to the Theiagen Google artifact registry:
+
+```bash
+# Build the docker image
+docker build --progres=plain --tag us-docker.pkg.dev/general-theiagen/theiagen/terra-tools:2024-08-27 terra-tools/2024-08-27/
+
+# Push the docker image to the Theiagen Google artifact registry
+docker push us-docker.pkg.dev/general-theiagen/theiagen/terra-tools:2024-08-27
 ```


### PR DESCRIPTION
- adds `csvkit` to the terra-tools docker image
- updated readme with new package 
- updated readme with a changelog & example commands for building and pushing images to our GAR

Keeping this as a draft until automation has been extensively tested with this docker image. We may need to make further adjustments depending on how things go.

Will mark ready for review when we're satisfied

CC @sage-wright 