### PR TITLE
[ARLN Stats] Add container for task_arln_stats.wdl

### DIFF
--- a/arln_stats/1.0.0/Dockerfile
+++ b/arln_stats/1.0.0/Dockerfile
@@ -1,0 +1,49 @@
+FROM ubuntu:jammy AS app
+
+ARG ARLN_STATS_VERSION="0.1.0"
+
+# Metadata
+LABEL base.image="ubuntu:jammy"
+LABEL software="ARLN_Stats"
+LABEL software.version="${ARLN_STATS_VERSION}"
+LABEL description="Docker image for task_arln_stats.wdl used to agregate and calculate statistics needed for ARLN submissions"
+LABEL maintainer="Andrew Hale"
+LABEL maintainer.email="andrew.hale@theiagen.com"
+
+# Install Python and dependencies
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    python3 \
+    python3-venv \
+    python3-pip \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/* \
+    && ln -sf /usr/bin/python3 /usr/bin/python \
+    && ln -sf /usr/bin/pip3 /usr/bin/pip
+
+# Install system dependencies
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential \
+    libz-dev \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install Python packages for FASTQ handling
+RUN pip install --no-cache-dir \
+    biopython
+
+# Create and set working directory
+WORKDIR /data
+COPY *.fastq.gz NCBI_Assembly_stats_20240124.txt ./
+
+WORKDIR /scripts
+COPY *.py ./
+
+# Step 2: Testing stage
+FROM app AS test
+
+WORKDIR /test
+
+RUN mv ../data/*.fastq.gz /test/ && \
+    python ../scripts/q30.py -i *_R1_001.fastq.gz >> q30_test.txt && \
+    python ../scripts/q30.py -i *_R1_001.fastq.gz >> q30_test.txt && \
+    cat q30_test.txt

--- a/arln_stats/1.0.0/Dockerfile
+++ b/arln_stats/1.0.0/Dockerfile
@@ -1,6 +1,7 @@
 FROM ubuntu:jammy AS app
 
 ARG ARLN_STATS_VERSION="0.1.0"
+ARG NCBI_ASSEMBLY_STATS_VERSION="20240124"
 
 # Metadata
 LABEL base.image="ubuntu:jammy"
@@ -33,7 +34,7 @@ RUN pip install --no-cache-dir \
 
 # Create and set working directory
 WORKDIR /data
-COPY NCBI_Assembly_stats_20240124.txt ./
+COPY NCBI_Assembly_stats_${NCBI_ASSEMBLY_STATS_VERSION}.txt ./
 
 WORKDIR /scripts
 COPY *.py ./

--- a/arln_stats/1.0.0/Dockerfile
+++ b/arln_stats/1.0.0/Dockerfile
@@ -33,7 +33,7 @@ RUN pip install --no-cache-dir \
 
 # Create and set working directory
 WORKDIR /data
-COPY *.fastq.gz NCBI_Assembly_stats_20240124.txt ./
+COPY NCBI_Assembly_stats_20240124.txt ./
 
 WORKDIR /scripts
 COPY *.py ./
@@ -43,7 +43,4 @@ FROM app AS test
 
 WORKDIR /test
 
-RUN mv ../data/*.fastq.gz /test/ && \
-    python ../scripts/q30.py -i *_R1_001.fastq.gz >> q30_test.txt && \
-    python ../scripts/q30.py -i *_R1_001.fastq.gz >> q30_test.txt && \
-    cat q30_test.txt
+RUN python ../scripts/q30.py -h

--- a/arln_stats/1.0.0/q30.py
+++ b/arln_stats/1.0.0/q30.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+
+import os
+import sys
+import gzip
+import argparse
+
+# Disable cache usage in Python so __pycache__ isn't formed.
+sys.dont_write_bytecode = True
+
+# Function to get the script version
+def get_version():
+    return "2.0.0"
+
+def parseArgs(args=None):
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--version', action='version', version=get_version())  # Add an argument to display the version
+    parser.add_argument('-i', '--input_reads', dest='input', required=True, help='FASTQs', nargs='+')
+    return parser.parse_args()
+
+def qual_stat(qstr):
+    q20 = 0
+    q30 = 0
+    for q in qstr:
+        qual = ord(q) - 33  # Remove chr() to directly use the character
+        if qual >= 30:
+            q30 += 1
+            q20 += 1
+        elif qual >= 20:
+            q20 += 1
+    return q20, q30
+
+def stat(filename, read_num):
+    total_read_count = 0
+    total_base_count = 0
+    q20_count = 0
+    q30_count = 0
+
+    # Check if the input file is gzipped
+    open_func = gzip.open if filename.endswith('.gz') else open
+
+    with open_func(filename, 'rt') as f:
+        while True:
+            header = f.readline()
+            if not header:  # End of file
+                break
+            sequence = f.readline().strip()
+            plus_line = f.readline()  # Skip the '+' line
+            quality_str = f.readline().strip()
+
+            total_read_count += 1
+            total_base_count += len(sequence)
+            q20, q30 = qual_stat(quality_str)
+            q20_count += q20
+            q30_count += q30
+    
+    print(read_num, 100 * (float(q30_count) / float(total_base_count))) 
+
+def main():
+    args = parseArgs()
+
+    for i, filename in enumerate(args.input):
+        read_num = f"read{i+1}"
+        stat(filename, read_num)
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Summary: This container is used to house the q30.py script for use within task_arln_stats.wdl as well as housing the NCBI_Assembly_Stats file that is an aggregation of NCBI assembly data. Keeping this within a container will allow us to version control the updates to the file when NCBI updates via their FTP site. 