### PR TITLE
[IRMA QC Summary] Set defaults to "N/A" and include "fillna" when writing CSV

### DIFF
--- a/irma/irma_helper.py
+++ b/irma/irma_helper.py
@@ -273,9 +273,9 @@ def variant_parsing(logger: logging.Logger,
   insertion_files = pd.DataFrame()
 
   # Set default variant counts
-  variant_count = ""
-  insertion_count = ""
-  deletion_count = ""
+  variant_count = "N/A"
+  insertion_count = "N/A"
+  deletion_count = "N/A"
 
   # Using var_types reference dictionary obtain variant frequency for each type per segment
   # and append to concatenated variant files
@@ -391,7 +391,7 @@ def create_mira_qc(
     logger.error(f"Error writing variant files: {e}")
 
   # Fill empty entries with N/A and write QC summary file
-  qc_df.replace(['', None], "N/A", inplace=True)
+  qc_df.fillna("N/A", inplace=True)  # Replace None or "" values
   qc_df.to_csv(input_dir / f"{samplename}_irma_qc_summary.tsv", sep="\t", index=False)
   logger.debug("QC summary written.")
 

--- a/irma/irma_helper.py
+++ b/irma/irma_helper.py
@@ -207,9 +207,9 @@ def read_counts(
       logger.info(f"Total Reads found to be{total_reads}; Passing Reads found to be {pass_qc_reads} for {segment}")
     else:
       logger.info(f"Entry for {segment} is not present. Setting read counts to NA.")
-      total_reads = ""
-      pass_qc_reads = ""
-      reads_mapped = ""
+      total_reads = "N/A"
+      pass_qc_reads = "N/A"
+      reads_mapped = "N/A"
 
   except FileNotFoundError:
     logger.warning(f"WARNING: READ_COUNTS.tsv file not found for {samplename}. Cannot extract read counts of segment {segment} for QC summary.")


### PR DESCRIPTION
This PR updates the IRMA helper script within the IRMA image to set fields in the QC Summary to "N/A" by default as opposed to empty or None. Also included is a `fillna` function to capture any other null entries and setting them to "N/A". This has the downstream affect of allowing QC Check to set the "N/A" strings to 0s for parsing. Previously there were empty entries in the summary table when some segments were left unassembled causing the QC Check task to fail when parsing and converting "N/A" to 0s. 

Testing was performed on a dev branch with a dev image. A prod image will be built and pushed on merge:
[Test](https://app.terra.bio/#workspaces/theiagen-training-workspaces/Theiagen_Hale_Sandbox/submission_history/246a2060-ade2-4216-b006-60f2fcc7e72d)
Intended functionality is when a segment is missing or has a missing entity in the summary it will be displayed as "N/A".
Dev branch is also undergoing analyst testing. 